### PR TITLE
Add dependency for boost::coroutine and boost::fiber on boost::context library

### DIFF
--- a/add_path.cpp
+++ b/add_path.cpp
@@ -269,6 +269,10 @@ static const std::pair<fs::path, fs::path>
       std::pair<fs::path, fs::path>("boost/preprocessor/slot/counter.hpp", "boost/preprocessor/slot/detail/counter.hpp"),
       std::pair<fs::path, fs::path>("boost/graph/distributed/detail/tag_allocator.hpp", "libs/graph_parallel"),
       std::pair<fs::path, fs::path>("boost/graph/distributed/mpi_process_group.hpp", "libs/graph_parallel"),
+      std::pair<fs::path, fs::path>("libs/coroutine/build/Jamfile.v2", "libs/context/src"),
+      std::pair<fs::path, fs::path>("libs/coroutine/build/Jamfile.v2", "libs/context/build"),
+      std::pair<fs::path, fs::path>("libs/fiber/build/Jamfile.v2", "libs/context/src"),
+      std::pair<fs::path, fs::path>("libs/fiber/build/Jamfile.v2", "libs/context/build"),
    };
 
    for(unsigned int n = 0; n < (sizeof(specials)/sizeof(specials[0])); ++n)


### PR DESCRIPTION
Without these lines, copied `coroutine` or `fiber` libraries fail to build as they depend on `segmented-stacks` feature which is defined in context library.