### PR TITLE
add option to exclude files from scan

### DIFF
--- a/add_path.cpp
+++ b/add_path.cpp
@@ -22,6 +22,8 @@
 
 void bcp_implementation::add_path(const fs::path& p)
 {
+   if (m_excluded.find(p) != m_excluded.end())
+      return;
    fs::path normalized_path = p;
     normalized_path.normalize();
    if(fs::exists(m_boost_path / normalized_path))
@@ -75,7 +77,8 @@ void bcp_implementation::add_directory(const fs::path& p)
       if(!m_dependencies.count(np)) 
       {
          m_dependencies[np] = p; // set up dependency tree
-         add_pending_path(np);
+         if (m_excluded.find(np) == m_excluded.end())
+            add_pending_path(np);
       }
       ++i;
    }

--- a/bcp.hpp
+++ b/bcp.hpp
@@ -38,6 +38,7 @@ public:
    virtual void set_namespace(const char* name) = 0;
    virtual void set_namespace_alias(bool) = 0;
    virtual void set_namespace_list(bool) = 0;
+   virtual void add_excluded(const char* p) = 0;
 
    virtual int run() = 0;
 

--- a/bcp_imp.cpp
+++ b/bcp_imp.cpp
@@ -118,6 +118,16 @@ void bcp_implementation::set_namespace_list(bool b)
    m_list_mode = b;
 }
 
+void bcp_implementation::add_excluded(const char* p)
+{
+   if (!fs::exists(p))
+   {
+      std::cerr << "CAUTION: excluded path " << p << " does not exist." << std::endl;
+      return;
+   } 
+   m_excluded.insert(p);     
+}
+
 fs::path get_short_path(const fs::path& p)
 {
    // truncate path no more than "x/y":

--- a/bcp_imp.hpp
+++ b/bcp_imp.hpp
@@ -67,6 +67,7 @@ private:
    void set_namespace(const char* name);
    void set_namespace_alias(bool);
    void set_namespace_list(bool);
+   void add_excluded(const char* p);
 
    virtual int run();
 
@@ -117,5 +118,6 @@ private:
    std::set<std::string>                                 m_lib_names;                  // List of library binary names
    std::map<std::string, fs::path>                       m_top_namespaces;             // List of top level namespace names
    std::queue<fs::path, std::list<fs::path> >            m_pending_paths;              // Queue of paths we haven't scanned yet.
+   std::set<fs::path, path_less>                         m_excluded;                   // paths to ignore in scan
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -42,6 +42,7 @@ void show_usage()
       "   --unix-lines     make sure that all copied files use Unix style line endings\n"
       "   --namespace=name rename the boost namespace to name (also changes library names).\n"
       "   --namespace-alias Makes namespace boost an alias of the namespace set with --namespace.\n"
+      "   --exclude         path to exclude from the scan, can be repeated\n"
       "\n"
       "module-list:         a list of boost files or library names to copy\n"
       "html-file:           the name of a html file to which the report will be written\n"
@@ -151,6 +152,10 @@ int cpp_main(int argc, char* argv[])
          list_mode = true;
          papp->set_namespace_list(true);
       }
+      else if(0 == std::strncmp("--exclude=", argv[i], 10))
+      {
+         papp->add_excluded(argv[i] + 10);
+      }      
       else if(argv[i][0] == '-')
       {
          std::cout << "Error: Unknown argument " << argv[i] << std::endl;


### PR DESCRIPTION
Adds an option to exclude paths from module scan. I need this for Boost.Histogram, which depends on a large part of boost only indirectly through tests and examples. When copying histogram, I don't want to include these dependencies.